### PR TITLE
允许beforeClose返回值以阻止关闭窗口，RadioGroup允许水平排列

### DIFF
--- a/lib/widgets/dialog.dart
+++ b/lib/widgets/dialog.dart
@@ -34,7 +34,7 @@ class NDialog extends StatefulWidget {
   // 点击取消按钮时触发
   final Function() onCancel;
   // 关闭前的回调函数
-  final Function() beforeClose;
+  final Future<bool> Function() beforeClose;
   // 自定义内容
   final Widget child;
 
@@ -67,18 +67,21 @@ class _NDialog extends State<NDialog> {
   bool _confirmLoading = false;
 
   confirmDialog() async {
+    bool close = true;
     if (widget.beforeClose != null) {
       setState(() {
         _confirmLoading = true;
       });
-      await widget.beforeClose();
+      close = await widget.beforeClose();
     }
     setState(() {
       _confirmLoading = false;
     });
-    hideDialog();
-    if (widget.onConfirm != null) {
-      widget.onConfirm();
+    if (close) {
+      hideDialog();
+      if (widget.onConfirm != null) {
+        widget.onConfirm();
+      }
     }
   }
 

--- a/lib/widgets/radioGroup.dart
+++ b/lib/widgets/radioGroup.dart
@@ -19,6 +19,8 @@ class RadioGroup extends StatefulWidget {
   final Color checkedColor;
   // 是否为单元格组件
   final bool inCellGroup;
+  // 布局方式
+  final Axis direction;
   // 当绑定值变化时触发的事件
   final Function(String val) onChange;
 
@@ -31,7 +33,9 @@ class RadioGroup extends StatefulWidget {
       this.checkedColor,
       this.inCellGroup: false,
       this.onChange,
-      this.iconSize})
+      this.iconSize,
+      this.direction: Axis.vertical
+      })
       : super(key: key);
 
   @override
@@ -84,9 +88,10 @@ class _RadioGroup extends State<RadioGroup> {
         ? CellGroup(
             children: <Widget>[...buildItems()],
           )
-        : Column(
+        : widget.direction == Axis.vertical ?  Column(
             children: <Widget>[...buildItems()],
-          );
+          ) : Row(mainAxisAlignment: MainAxisAlignment.spaceAround, children: <Widget>[...buildItems()]
+    ) ;
   }
 }
 


### PR DESCRIPTION
Dialog在提交时，并不检查child的返回，因此请求出错时窗口也会关闭，这个commit用于beforeClose返回一个bool，如果为false，则窗口不关闭。

另外，添加direction参数使RadioGroup可以水平排列